### PR TITLE
feat: support for retina screens

### DIFF
--- a/sourcecode
+++ b/sourcecode
@@ -19,6 +19,7 @@ def setup():
     
     size(700, 700)
     frameRate(30)
+    pixelDensity(displayDensity())
     background(0)
     global myBus
     myBus = MidiBus(this, -1, "Bus 1")


### PR DESCRIPTION
Add auto `pixelDensity` setting for smooth rendering on retina screens. 

Before:
![image](https://cloud.githubusercontent.com/assets/1027871/21197271/c49dde28-c232-11e6-87e8-df668f7af7f1.png)

After:
![image](https://cloud.githubusercontent.com/assets/1027871/21197273/cc8a80f0-c232-11e6-8fad-0893c2136a29.png)

Thanks for great tool!
_nabionix_

